### PR TITLE
adds specific LineBillingSpecifiedPeriod

### DIFF
--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -12,6 +12,16 @@ from .fields import (
 )
 
 
+# added as in lines there is no period description and in BillingSpecifiedPeriod it is mandatory
+class LineBillingSpecifiedPeriod(Element):
+    start = DateTimeField(NS_RAM, "StartDateTime", required=True, profile=COMFORT)
+    end = DateTimeField(NS_RAM, "EndDateTime", required=True, profile=COMFORT)
+
+    class Meta:
+        namespace = NS_RAM
+        tag = "BillingSpecifiedPeriod"
+
+
 class BillingSpecifiedPeriod(Element):
     description = StringField(
         NS_RAM,

--- a/drafthorse/models/tradelines.py
+++ b/drafthorse/models/tradelines.py
@@ -1,7 +1,7 @@
 from . import BASIC, COMFORT, EXTENDED, NS_RAM
 from .accounting import (
     ApplicableTradeTax,
-    BillingSpecifiedPeriod,
+    LineBillingSpecifiedPeriod,
     ReceivableAccountingAccount,
     TradeAllowanceCharge,
 )
@@ -151,7 +151,7 @@ class LineSummation(Element):
 
 class LineSettlement(Element):
     trade_tax = Field(ApplicableTradeTax, required=False, profile=COMFORT)
-    period = Field(BillingSpecifiedPeriod, required=False, profile=COMFORT)
+    period = Field(LineBillingSpecifiedPeriod, required=False, profile=COMFORT)
     allowance_charge = MultiField(
         TradeAllowanceCharge,
         required=False,


### PR DESCRIPTION
adds specific LineBillingSpecifiedPeriod without the (required) documentation field to fix Issue #16 and to align with the ZUGFeRD 2.2 specification