### PR TITLE
Corrects the attribute order of ApplicableTradeTax

### DIFF
--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -83,13 +83,6 @@ class ApplicableTradeTax(Element):
         profile=COMFORT,
         _d="Grund der Steuerbefreiung (Freitext)",
     )
-    exemption_reason_code = StringField(
-        NS_RAM,
-        "ExemptionReasonCode",
-        required=False,
-        profile=EXTENDED,
-        _d="Grund der Steuerbefreiung (Code)",
-    )
     tax_point_date = DateTimeField(
         NS_RAM, "TaxPointDate", required=False, profile=COMFORT
     )
@@ -126,6 +119,13 @@ class ApplicableTradeTax(Element):
         required=False,
         profile=COMFORT,
         _d="Steuerkategorie (Wert)",
+    )
+    exemption_reason_code = StringField(
+        NS_RAM,
+        "ExemptionReasonCode",
+        required=False,
+        profile=EXTENDED,
+        _d="Grund der Steuerbefreiung (Code)",
     )
     rate_applicable_percent = DecimalField(
         NS_RAM, "RateApplicablePercent", required=True, profile=BASIC


### PR DESCRIPTION
Aligns the attribute order in class `ApplicableTradeTax` with `TradeTaxType` of `FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd` fixing Issue #18