### PR TITLE
Fixes buyer_order date time validation error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Parsing::
 Generating::
 
     import os
-    from datetime import date
+    from datetime import date, datetime
     from decimal import Decimal
 
     from drafthorse.models.accounting import ApplicableTradeTax
@@ -65,6 +65,8 @@ Generating::
 
     doc.trade.settlement.currency_code = "EUR"
     doc.trade.settlement.payment_means.type_code = "ZZZ"
+
+    doc.trade.agreement.buyer_order.issue_date_time = datetime.now()
 
     li = LineItem()
     li.document.line_id = "1"

--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -3,6 +3,7 @@ from .elements import Element
 from .fields import (
     CurrencyField,
     DateTimeField,
+    FormattedDateTimeField,
     DecimalField,
     IndicatorField,
     MultiCurrencyField,
@@ -26,6 +27,17 @@ class BillingSpecifiedPeriod(Element):
     class Meta:
         namespace = NS_RAM
         tag = "BillingSpecifiedPeriod"
+
+
+class BuyerOrderReferencedDocument(Element):
+    issuer_ID = StringField(NS_RAM, "IssuerAssignedID", profile=COMFORT)
+    issue_date_time = FormattedDateTimeField(
+        NS_RAM, "FormattedIssueDateTime", required=True, profile=EXTENDED
+    )
+
+    class Meta:
+        namespace = NS_RAM
+        tag = "BuyerOrderReferencedDocument"
 
 
 class SellerOrderReferencedDocument(Element):

--- a/drafthorse/models/fields.py
+++ b/drafthorse/models/fields.py
@@ -255,6 +255,25 @@ class DateTimeField(Field):
         return self.cls(self.namespace, self.tag)
 
 
+class FormattedDateTimeField(Field):
+    def __init__(
+        self, namespace, tag, default=False, required=False, profile=BASIC, _d=None
+    ):
+        from .elements import FormattedDateTimeElement
+
+        super().__init__(FormattedDateTimeElement, default, required, profile, _d)
+        self.namespace = namespace
+        self.tag = tag
+
+    def __set__(self, instance, value):
+        if instance._data.get(self.name, None) is None:
+            instance._data[self.name] = self.initialize()
+        instance._data[self.name]._value = value
+
+    def initialize(self):
+        return self.cls(self.namespace, self.tag)
+
+
 class DirectDateTimeField(Field):
     def __init__(
         self, namespace, tag, default=False, required=False, profile=BASIC, _d=None

--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -21,12 +21,6 @@ class ReferencedDocument(Element):
     )
 
 
-class BuyerOrderReferencedDocument(ReferencedDocument):
-    class Meta:
-        namespace = NS_RAM
-        tag = "BuyerOrderReferencedDocument"
-
-
 class ContractReferencedDocument(ReferencedDocument):
     class Meta:
         namespace = NS_RAM

--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -5,6 +5,7 @@ from .accounting import (
     BillingSpecifiedPeriod,
     MonetarySummation,
     ReceivableAccountingAccount,
+    BuyerOrderReferencedDocument,
     SellerOrderReferencedDocument,
     TradeAllowanceCharge,
 )
@@ -27,7 +28,6 @@ from .payment import (
 )
 from .references import (
     AdditionalReferencedDocument,
-    BuyerOrderReferencedDocument,
     ContractReferencedDocument,
     InvoiceReferencedDocument,
     ProcuringProjectType,

--- a/tests/test_mininal.py
+++ b/tests/test_mininal.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from drafthorse.models.accounting import ApplicableTradeTax
@@ -32,6 +32,8 @@ def test_readme_construction_example():
 
     doc.trade.settlement.currency_code = "EUR"
     doc.trade.settlement.payment_means.type_code = "ZZZ"
+
+    doc.trade.agreement.buyer_order.issue_date_time = datetime.now()
 
     li = LineItem()
     li.document.line_id = "1"


### PR DESCRIPTION
Moves BuyerOrderReferencedDocument to accounting.py, align the date time property name to the one of SellerOrderReferenceDocument and make it use FormattedDateTimeField to fix Issue #22.