### PR TITLE
fixes Issue #20, Issue #22, Issue #26 and Issue #29. It replaces PR #21 and PR #23 and contains alignments to the v2.2 specification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,14 @@ Generating::
     doc.trade.settlement.currency_code = "EUR"
     doc.trade.settlement.payment_means.type_code = "ZZZ"
 
+    doc.trade.agreement.seller.address.country_id = "DE"
+    doc.trade.agreement.seller.address.country_subdivision = "Bayern"
+
+    doc.trade.agreement.seller_order.issue_date_time = datetime.now(timezone.utc)
+    doc.trade.agreement.buyer_order.issue_date_time = datetime.now(timezone.utc)
+    doc.trade.settlement.advance_payment.received_date = datetime.now(timezone.utc)
+    doc.trade.agreement.customer_order.issue_date_time = datetime.now(timezone.utc)
+
     li = LineItem()
     li.document.line_id = "1"
     li.product.name = "Rainbow"

--- a/drafthorse/models/__init__.py
+++ b/drafthorse/models/__init__.py
@@ -4,7 +4,7 @@ NS_A = "urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
 NS_RAM = (
     "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
 )
-NS_QDT = "urn:un:unece:uncefact:data:standard:QualifiedDataType:10"
+NS_QDT = "urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
 BASIC = "BASIC"
 COMFORT = "COMFORT"
 EXTENDED = "EXTENDED"

--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -237,7 +237,7 @@ class TradeAllowanceCharge(Element):
         profile=COMFORT,
         _d="Betrag des Zu-/Abschlags",
     )
-    reason_code = StringField(NS_RAM, "ReasonCode", required=False, profile=EXTENDED)
+    reason_code = StringField(NS_RAM, "ReasonCode", required=False, profile=COMFORT)
     reason = StringField(NS_RAM, "Reason", required=False, profile=COMFORT)
     trade_tax = MultiField(CategoryTradeTax, required=False, profile=COMFORT)
 

--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -28,36 +28,6 @@ class BillingSpecifiedPeriod(Element):
         tag = "BillingSpecifiedPeriod"
 
 
-class LineApplicableTradeTax(Element):
-    calculated_amount = DecimalField(
-        NS_RAM, "CalculatedAmount", required=True, profile=BASIC, _d="Steuerbetrag"
-    )
-    type_code = StringField(
-        NS_RAM, "TypeCode", required=True, profile=BASIC, _d="Steuerart (Code)"
-    )
-    exemption_reason = StringField(
-        NS_RAM,
-        "ExemptionReason",
-        required=False,
-        profile=COMFORT,
-        _d="Grund der Steuerbefreiung (Freitext)",
-    )
-    category_code = StringField(
-        NS_RAM,
-        "CategoryCode",
-        required=False,
-        profile=COMFORT,
-        _d="Steuerkategorie (Wert)",
-    )
-    rate_applicable_percent = DecimalField(
-        NS_RAM, "RateApplicablePercent", required=True, profile=BASIC
-    )
-
-    class Meta:
-        namespace = NS_RAM
-        tag = "ApplicableTradeTax"
-
-
 class ApplicableTradeTax(Element):
     calculated_amount = DecimalField(
         NS_RAM, "CalculatedAmount", required=True, profile=BASIC, _d="Steuerbetrag"
@@ -69,17 +39,8 @@ class ApplicableTradeTax(Element):
         NS_RAM,
         "ExemptionReason",
         required=False,
-        profile=COMFORT,
-        _d="Grund der Steuerbefreiung (Freitext)",
-    )
-    tax_point_date = DateTimeField(
-        NS_RAM, "TaxPointDate", required=False, profile=COMFORT
-    )
-    due_date_type_code = StringField(
-        NS_RAM,
-        "DueDateTypeCode",
-        required=False,
         profile=BASIC,
+        _d="Grund der Steuerbefreiung (Freitext)",
     )
     basis_amount = DecimalField(
         NS_RAM,
@@ -106,15 +67,24 @@ class ApplicableTradeTax(Element):
         NS_RAM,
         "CategoryCode",
         required=False,
-        profile=COMFORT,
+        profile=BASIC,
         _d="Steuerkategorie (Wert)",
     )
     exemption_reason_code = StringField(
         NS_RAM,
         "ExemptionReasonCode",
         required=False,
-        profile=EXTENDED,
+        profile=BASIC,
         _d="Grund der Steuerbefreiung (Code)",
+    )
+    tax_point_date = DateTimeField(
+        NS_RAM, "TaxPointDate", required=False, profile=COMFORT
+    )
+    due_date_type_code = StringField(
+        NS_RAM,
+        "DueDateTypeCode",
+        required=False,
+        profile=BASIC,
     )
     rate_applicable_percent = DecimalField(
         NS_RAM, "RateApplicablePercent", required=True, profile=BASIC

--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -28,17 +28,6 @@ class BillingSpecifiedPeriod(Element):
         tag = "BillingSpecifiedPeriod"
 
 
-class SellerOrderReferencedDocument(Element):
-    issuer_ID = StringField(NS_RAM, "IssuerAssignedID", profile=COMFORT)
-    issue_date_time = DateTimeField(
-        NS_RAM, "FormattedIssueDateTime", required=True, profile=EXTENDED
-    )
-
-    class Meta:
-        namespace = NS_RAM
-        tag = "SellerOrderReferencedDocument"
-
-
 class LineApplicableTradeTax(Element):
     calculated_amount = DecimalField(
         NS_RAM, "CalculatedAmount", required=True, profile=BASIC, _d="Steuerbetrag"

--- a/drafthorse/models/accounting.py
+++ b/drafthorse/models/accounting.py
@@ -213,14 +213,14 @@ class TradeAllowanceCharge(Element):
         NS_RAM,
         "CalculationPercent",
         required=False,
-        profile=EXTENDED,
+        profile=COMFORT,
         _d="Rabatt in Prozent",
     )
     basis_amount = DecimalField(  # TODO: Should be deprecated?
         NS_RAM,
         "BasisAmount",
         required=False,
-        profile=EXTENDED,
+        profile=COMFORT,
         _d="Basisbetrag des Rabatts",
     )
     basis_quantity = QuantityField(

--- a/drafthorse/models/elements.py
+++ b/drafthorse/models/elements.py
@@ -80,7 +80,7 @@ class Element(metaclass=BaseElementMeta):
         if (
             not hasattr(self, key)
             and not key.startswith("_")
-            and not key in ("required",)
+            and key not in ("required",)
         ):
             raise AttributeError(
                 f"Element {type(self)} has no attribute '{key}'. If you set it, it would not be included in the output."
@@ -319,14 +319,17 @@ class IDElement(StringElement):
 
 
 class DateTimeElement(StringElement):
-    def __init__(self, namespace, tag, value=None, format="102"):
+    def __init__(
+        self, namespace, tag, value=None, format="102", date_time_namespace=NS_UDT
+    ):
         super().__init__(namespace, tag)
         self._value = value
         self._format = format
+        self._date_time_namespace = date_time_namespace
 
     def to_etree(self):
         t = self._etree_node()
-        node = ET.Element("{%s}%s" % (NS_UDT, "DateTimeString"))
+        node = ET.Element("{%s}%s" % (self._date_time_namespace, "DateTimeString"))
         if self._value:
             if self._format == "102":
                 node.text = self._value.strftime("%Y%m%d")
@@ -344,7 +347,7 @@ class DateTimeElement(StringElement):
     def from_etree(self, root):
         if len(root) != 1:
             raise TypeError("Date containers should have one child")
-        if root[0].tag != "{%s}%s" % (NS_UDT, "DateTimeString"):
+        if root[0].tag != "{%s}%s" % (self._date_time_namespace, "DateTimeString"):
             raise TypeError("Tag %s not recognized" % root[0].tag)
         self._format = root[0].attrib["format"]
         if self._format == "102":

--- a/drafthorse/models/elements.py
+++ b/drafthorse/models/elements.py
@@ -301,7 +301,8 @@ class IDElement(StringElement):
     def to_etree(self):
         node = self._etree_node()
         node.text = self._text
-        node.attrib["schemeID"] = self._scheme_id
+        if self._scheme_id != "":
+            node.attrib["schemeID"] = self._scheme_id
         return node
 
     def from_etree(self, root):

--- a/drafthorse/models/fields.py
+++ b/drafthorse/models/fields.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from . import BASIC
+from . import BASIC, NS_UDT
 from .container import (
     Container,
     CurrencyContainer,
@@ -238,13 +238,21 @@ class IndicatorField(Field):
 
 class DateTimeField(Field):
     def __init__(
-        self, namespace, tag, default=False, required=False, profile=BASIC, _d=None
+        self,
+        namespace,
+        tag,
+        default=False,
+        required=False,
+        profile=BASIC,
+        _d=None,
+        date_time_namespace=NS_UDT,
     ):
         from .elements import DateTimeElement
 
         super().__init__(DateTimeElement, default, required, profile, _d)
         self.namespace = namespace
         self.tag = tag
+        self._date_time_namespace = date_time_namespace
 
     def __set__(self, instance, value):
         if instance._data.get(self.name, None) is None:
@@ -252,7 +260,9 @@ class DateTimeField(Field):
         instance._data[self.name]._value = value
 
     def initialize(self):
-        return self.cls(self.namespace, self.tag)
+        return self.cls(
+            self.namespace, self.tag, date_time_namespace=self._date_time_namespace
+        )
 
 
 class DirectDateTimeField(Field):

--- a/drafthorse/models/fields.py
+++ b/drafthorse/models/fields.py
@@ -119,10 +119,16 @@ class IDField(Field):
         if instance._data.get(self.name, None) is None:
             instance._data[self.name] = self.initialize()
 
-        if not isinstance(value, (tuple, list)):
-            raise TypeError("Please pass a 2-tuple of including scheme ID and ID.")
-        instance._data[self.name]._text = value[1]
-        instance._data[self.name]._scheme_id = value[0]
+        if isinstance(value, (tuple, list)):
+            if len(value) == 2:
+                instance._data[self.name]._text = value[1]
+                instance._data[self.name]._scheme_id = value[0]
+            else:
+                raise TypeError(
+                    "Please pass a 2-tuple of including scheme ID and ID, or just an ID."
+                )
+        else:
+            instance._data[self.name]._text = value
 
 
 class CurrencyField(Field):
@@ -208,7 +214,9 @@ class BinaryObjectField(Field):
             instance._data[self.name] = self.initialize()
 
         if not isinstance(value, (tuple, list)):
-            raise TypeError("Please pass a 2-tuple of including amount and unit code.")
+            raise TypeError(
+                "Please pass a 3-tuple of mimeCode, filename and base64-encoded binary."
+            )
         instance._data[self.name]._text = value[2]
         instance._data[self.name]._mime_code = value[0]
         instance._data[self.name]._filename = value[1]

--- a/drafthorse/models/party.py
+++ b/drafthorse/models/party.py
@@ -117,6 +117,12 @@ class PayeeTradeParty(TradeParty):
         tag = "PayeeTradeParty"
 
 
+class PayerTradeParty(TradeParty):
+    class Meta:
+        namespace = NS_RAM
+        tag = "PayerTradeParty"
+
+
 class InvoicerTradeParty(TradeParty):
     class Meta:
         namespace = NS_RAM

--- a/drafthorse/models/product.py
+++ b/drafthorse/models/product.py
@@ -13,11 +13,11 @@ class ProductCharacteristic(Element):
     type_code = StringField(
         NS_RAM,
         "TypeCode",
-        required=True,
+        required=False,
         profile=EXTENDED,
         _d="Art der Produkteigenschaft",
     )
-    description = StringField(NS_RAM, "Description", required=True, profile=EXTENDED)
+    description = StringField(NS_RAM, "Description", required=True, profile=COMFORT)
     value_measure = QuantityField(
         NS_RAM,
         "ValueMeasure",
@@ -25,7 +25,7 @@ class ProductCharacteristic(Element):
         profile=EXTENDED,
         _d="Numerische Messgröße",
     )
-    value = StringField(NS_RAM, "Value", required=False, profile=EXTENDED)
+    value = StringField(NS_RAM, "Value", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
@@ -34,13 +34,24 @@ class ProductCharacteristic(Element):
 
 class ProductClassification(Element):
     class_code = ClassificationField(
-        NS_RAM, "ClassCode", required=True, profile=EXTENDED
+        NS_RAM, "ClassCode", required=False, profile=COMFORT
     )
-    value = StringField(NS_RAM, "ClassName", required=True, profile=EXTENDED)
+    value = StringField(NS_RAM, "ClassName", required=False, profile=EXTENDED)
 
     class Meta:
         namespace = NS_RAM
         tag = "DesignatedProductClassification"
+
+
+class ProductInstance(Element):
+    batch_id = IDField(NS_RAM, "BatchID", required=False, profile=EXTENDED)
+    serial_id = StringField(
+        NS_RAM, "SupplierAssignedSerialID", required=False, profile=EXTENDED
+    )
+
+    class Meta:
+        namespace = NS_RAM
+        tag = "IndividualTradeProductInstance"
 
 
 class OriginCountry(Element):
@@ -73,22 +84,20 @@ class ReferencedProduct(Element):
 
 
 class TradeProduct(Element):
-    global_id = IDField(NS_RAM, "GlobalID", required=False, profile=COMFORT)
+    id = IDField(NS_RAM, "ID", required=False, profile=EXTENDED)
+    global_id = IDField(NS_RAM, "GlobalID", required=False)
     seller_assigned_id = StringField(
         NS_RAM, "SellerAssignedID", required=False, profile=COMFORT
     )
     buyer_assigned_id = StringField(
         NS_RAM, "BuyerAssignedID", required=False, profile=COMFORT
     )
-    name = StringField(NS_RAM, "Name", required=False, profile=COMFORT)
+    name = StringField(NS_RAM, "Name", required=False)
     description = StringField(NS_RAM, "Description", required=False, profile=COMFORT)
-    characteristics = MultiField(
-        ProductCharacteristic, required=False, profile=EXTENDED
-    )
-    classifications = MultiField(
-        ProductClassification, required=False, profile=EXTENDED
-    )
-    origins = MultiField(OriginCountry, required=False, profile=EXTENDED)
+    characteristics = MultiField(ProductCharacteristic, required=False, profile=COMFORT)
+    classifications = MultiField(ProductClassification, required=False, profile=COMFORT)
+    instance = MultiField(ProductInstance, required=False, profile=EXTENDED)
+    origins = MultiField(OriginCountry, required=False, profile=COMFORT)
     included_products = MultiField(ReferencedProduct, required=False, profile=EXTENDED)
 
     class Meta:

--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -1,6 +1,6 @@
-from . import COMFORT, EXTENDED, NS_RAM
+from . import BASIC, COMFORT, EXTENDED, NS_RAM, NS_QDT
 from .elements import Element
-from .fields import BinaryObjectField, DirectDateTimeField, StringField
+from .fields import BinaryObjectField, DateTimeField, StringField
 
 
 class ProcuringProjectType(Element):
@@ -13,12 +13,22 @@ class ProcuringProjectType(Element):
 
 
 class ReferencedDocument(Element):
-    date_time_string = DirectDateTimeField(
-        NS_RAM, "DateTimeString", required=False, profile=COMFORT
-    )
     issuer_assigned_id = StringField(
-        NS_RAM, "IssuerAssignedID", required=False, profile=COMFORT
+        NS_RAM, "IssuerAssignedID", required=False, profile=BASIC
     )
+    issue_date_time = DateTimeField(
+        NS_RAM,
+        "FormattedIssueDateTime",
+        required=True,
+        profile=BASIC,
+        date_time_namespace=NS_QDT,
+    )
+
+
+class SellerOrderReferencedDocument(ReferencedDocument):
+    class Meta:
+        namespace = NS_RAM
+        tag = "SellerOrderReferencedDocument"
 
 
 class BuyerOrderReferencedDocument(ReferencedDocument):
@@ -33,18 +43,12 @@ class ContractReferencedDocument(ReferencedDocument):
         tag = "ContractReferencedDocument"
 
 
-class AdditionalReferencedDocument(Element):
-    issuer_assigned_id = StringField(
-        NS_RAM, "IssuerAssignedID", required=False, profile=COMFORT
-    )
-    uri_id = StringField(NS_RAM, "URIID", required=False, profile=EXTENDED)
-    date_time_string = DirectDateTimeField(
-        NS_RAM, "DateTimeString", required=False, profile=COMFORT
-    )
-    type_code = StringField(NS_RAM, "TypeCode", profile=EXTENDED, required=True)
+class AdditionalReferencedDocument(ReferencedDocument):
+    uri_id = StringField(NS_RAM, "URIID", required=False, profile=COMFORT)
+    type_code = StringField(NS_RAM, "TypeCode", profile=COMFORT, required=True)
     name = StringField(NS_RAM, "Name", profile=COMFORT, required=False)
     attached_object = BinaryObjectField(
-        NS_RAM, "AttachmentBinaryObject", required=False, profile=EXTENDED
+        NS_RAM, "AttachmentBinaryObject", required=False, profile=COMFORT
     )
 
     class Meta:
@@ -52,15 +56,8 @@ class AdditionalReferencedDocument(Element):
         tag = "AdditionalReferencedDocument"
 
 
-class InvoiceReferencedDocument(Element):
-    issuer_assigned_id = StringField(
-        NS_RAM, "IssuerAssignedID", required=False, profile=COMFORT
-    )
-
-    date_time_string = DirectDateTimeField(
-        NS_RAM, "DateTimeString", required=True, profile=COMFORT
-    )
-    type_code = StringField(NS_RAM, "TypeCode", profile=EXTENDED, required=False)
+class InvoiceReferencedDocument(ReferencedDocument):
+    type_code = StringField(NS_RAM, "TypeCode", profile=COMFORT, required=False)
 
     class Meta:
         namespace = NS_RAM
@@ -80,7 +77,7 @@ class DespatchAdviceReferencedDocument(ReferencedDocument):
 
 
 class LineUltimateCustomerOrderReferencedDocument(ReferencedDocument):
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
@@ -88,7 +85,7 @@ class LineUltimateCustomerOrderReferencedDocument(ReferencedDocument):
 
 
 class LineBuyerOrderReferencedDocument(ReferencedDocument):
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
@@ -96,7 +93,7 @@ class LineBuyerOrderReferencedDocument(ReferencedDocument):
 
 
 class LineContractReferencedDocument(ReferencedDocument):
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
@@ -104,7 +101,7 @@ class LineContractReferencedDocument(ReferencedDocument):
 
 
 class LineDespatchAdviceReferencedDocument(ReferencedDocument):
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
@@ -112,28 +109,24 @@ class LineDespatchAdviceReferencedDocument(ReferencedDocument):
 
 
 class LineReceivingAdviceReferencedDocument(ReferencedDocument):
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM
         tag = "ReceivingAdviceReferencedDocument"
 
 
-class LineAdditionalReferencedDocument(Element):
-    issuer_assigned_id = StringField(
-        NS_RAM, "IssuerAssignedID", required=False, profile=COMFORT
-    )
-    uri_id = StringField(NS_RAM, "URIID", required=False, profile=EXTENDED)
-    line_id = StringField(NS_RAM, "LineID", required=False, profile=EXTENDED)
-    type_code = StringField(NS_RAM, "TypeCode", required=False, profile=EXTENDED)
+class LineAdditionalReferencedDocument(ReferencedDocument):
+    uri_id = StringField(NS_RAM, "URIID", required=False, profile=COMFORT)
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
+    type_code = StringField(NS_RAM, "TypeCode", required=False, profile=COMFORT)
     name = StringField(NS_RAM, "Name", required=False, profile=EXTENDED)
-    date_time_string = DirectDateTimeField(
-        NS_RAM, "FormattedIssueDateTime", required=False, profile=COMFORT
-    )
     reference_type_code = StringField(
-        NS_RAM, "ReferenceTypeCode", profile=EXTENDED, required=True
+        NS_RAM, "ReferenceTypeCode", profile=COMFORT, required=True
     )
-    # todo: AttachmentBinaryObject
+    attached_object = BinaryObjectField(
+        NS_RAM, "AttachmentBinaryObject", required=False, profile=COMFORT
+    )
 
     class Meta:
         namespace = NS_RAM

--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -1,6 +1,6 @@
-from . import BASIC, COMFORT, EXTENDED, NS_RAM, NS_QDT
+from . import BASIC, COMFORT, NS_RAM, NS_QDT
 from .elements import Element
-from .fields import BinaryObjectField, DateTimeField, StringField
+from .fields import BinaryObjectField, DateTimeField, StringField, IDField
 
 
 class ProcuringProjectType(Element):
@@ -13,7 +13,7 @@ class ProcuringProjectType(Element):
 
 
 class ReferencedDocument(Element):
-    issuer_assigned_id = StringField(
+    issuer_assigned_id = IDField(
         NS_RAM, "IssuerAssignedID", required=False, profile=BASIC
     )
     issue_date_time = DateTimeField(
@@ -120,7 +120,7 @@ class LineAdditionalReferencedDocument(ReferencedDocument):
     uri_id = StringField(NS_RAM, "URIID", required=False, profile=COMFORT)
     line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
     type_code = StringField(NS_RAM, "TypeCode", required=False, profile=COMFORT)
-    name = StringField(NS_RAM, "Name", required=False, profile=EXTENDED)
+    name = StringField(NS_RAM, "Name", required=False, profile=COMFORT)
     reference_type_code = StringField(
         NS_RAM, "ReferenceTypeCode", profile=COMFORT, required=True
     )

--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -1,11 +1,10 @@
-from . import BASIC, COMFORT, EXTENDED, NS_RAM, NS_RSM
+from . import BASIC, COMFORT, EXTENDED, NS_RAM, NS_RSM, NS_QDT
 from .accounting import (
     ApplicableTradeTax,
     AppliedTradeTax,
     BillingSpecifiedPeriod,
     MonetarySummation,
     ReceivableAccountingAccount,
-    SellerOrderReferencedDocument,
     TradeAllowanceCharge,
 )
 from .delivery import TradeDelivery
@@ -27,6 +26,7 @@ from .payment import (
 )
 from .references import (
     AdditionalReferencedDocument,
+    SellerOrderReferencedDocument,
     BuyerOrderReferencedDocument,
     ContractReferencedDocument,
     InvoiceReferencedDocument,
@@ -147,7 +147,9 @@ class IncludedTradeTax(Element):
 
 class AdvancePayment(Element):
     paid_amount = DecimalField(NS_RAM, "PaidAmount")
-    received_date = DateTimeField(NS_RAM, "FormattedReceivedDateTime")
+    received_date = DateTimeField(
+        NS_RAM, "FormattedReceivedDateTime", date_time_namespace=NS_QDT
+    )
     included_trade_tax = MultiField(IncludedTradeTax)
 
     class Meta:

--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -16,6 +16,7 @@ from .party import (
     InvoiceeTradeParty,
     InvoicerTradeParty,
     PayeeTradeParty,
+    PayerTradeParty,
     SellerTaxRepresentativeTradeParty,
     SellerTradeParty,
 )
@@ -26,8 +27,8 @@ from .payment import (
 )
 from .references import (
     AdditionalReferencedDocument,
-    SellerOrderReferencedDocument,
     BuyerOrderReferencedDocument,
+    SellerOrderReferencedDocument,
     ContractReferencedDocument,
     InvoiceReferencedDocument,
     ProcuringProjectType,
@@ -161,47 +162,52 @@ class TradeSettlement(Element):
     creditor_reference_id = StringField(NS_RAM, "CreditorReferenceID")
     payment_reference = StringField(NS_RAM, "PaymentReference")
     tax_currency_code = StringField(
-        NS_RAM, "TaxCurrencyCode", required=False, profile=COMFORT
+        NS_RAM, "TaxCurrencyCode", required=False, profile=BASIC
     )
     currency_code = StringField(NS_RAM, "InvoiceCurrencyCode")
     issuer_reference = StringField(NS_RAM, "InvoiceIssuerReference", profile=EXTENDED)
     invoicer = Field(
-        InvoicerTradeParty, required=False, profile=COMFORT, _d="Rechnungsaussteller"
+        InvoicerTradeParty, required=False, profile=EXTENDED, _d="Rechnungsaussteller"
     )
     invoicee = Field(
-        InvoiceeTradeParty, required=False, profile=COMFORT, _d="Rechnungsempfänger"
+        InvoiceeTradeParty, required=False, profile=EXTENDED, _d="Rechnungsempfänger"
     )
     payee = Field(
-        PayeeTradeParty, required=False, profile=COMFORT, _d="Zahlungsempfänger"
+        PayeeTradeParty, required=False, profile=BASIC, _d="Zahlungsempfänger"
     )
-    invoice_currency = Field(TaxApplicableTradeCurrencyExchange)
+    payer = Field(
+        PayerTradeParty, required=False, profile=EXTENDED, _d="Zahlungspflichtiger"
+    )
+    invoice_currency = Field(TaxApplicableTradeCurrencyExchange, profile=EXTENDED)
     payment_means = Field(PaymentMeans)
     trade_tax = MultiField(ApplicableTradeTax)
     period = Field(BillingSpecifiedPeriod, required=False, profile=BASIC)
     allowance_charge = MultiField(
         TradeAllowanceCharge,
         required=False,
-        profile=COMFORT,
+        profile=BASIC,
         _d="Schalter für Zu-/Abschlag",
     )
-    service_charge = MultiField(LogisticsServiceCharge, required=False, profile=COMFORT)
-    terms = MultiField(PaymentTerms, required=False, profile=COMFORT)
+    service_charge = MultiField(
+        LogisticsServiceCharge, required=False, profile=EXTENDED
+    )
+    terms = MultiField(PaymentTerms, required=False, profile=BASIC)
     monetary_summation = Field(
         MonetarySummation,
         required=True,
         profile=BASIC,
         _d="Detailinformation zu Belegsummen",
     )
-    accounting_account = Field(
-        ReceivableAccountingAccount,
-        required=False,
-        profile=EXTENDED,
-        _d="Detailinformationen zur Buchungsreferenz",
-    )
-    advance_payment = MultiField(AdvancePayment, required=False, profile=EXTENDED)
     invoice_referenced_document = Field(
         InvoiceReferencedDocument, required=False, profile=BASIC
     )
+    accounting_account = Field(
+        ReceivableAccountingAccount,
+        required=False,
+        profile=BASIC,
+        _d="Detailinformationen zur Buchungsreferenz",
+    )
+    advance_payment = MultiField(AdvancePayment, required=False, profile=EXTENDED)
 
     class Meta:
         namespace = NS_RAM

--- a/drafthorse/models/tradelines.py
+++ b/drafthorse/models/tradelines.py
@@ -150,25 +150,24 @@ class LineSummation(Element):
 
 
 class LineSettlement(Element):
-    trade_tax = Field(ApplicableTradeTax, required=False, profile=COMFORT)
-    period = Field(BillingSpecifiedPeriod, required=False, profile=COMFORT)
+    trade_tax = Field(ApplicableTradeTax, required=False)
+    period = Field(BillingSpecifiedPeriod, required=False)
     allowance_charge = MultiField(
         TradeAllowanceCharge,
         required=False,
-        profile=COMFORT,
         _d="Schalter für Zu-/Abschlag",
     )
-    monetary_summation = Field(LineSummation, required=False, profile=COMFORT)
+    monetary_summation = Field(LineSummation, required=False, profile=BASIC)
     invoice_referenced_document = Field(
         InvoiceReferencedDocument, required=False, profile=EXTENDED
     )
     additional_referenced_document = Field(
-        LineAdditionalReferencedDocument, required=False, profile=EXTENDED
+        LineAdditionalReferencedDocument, required=False, profile=COMFORT
     )
     accounting_account = Field(
         ReceivableAccountingAccount,
         required=False,
-        profile=EXTENDED,
+        profile=COMFORT,
         _d="Detailinformationen zur Buchungsreferenz",
     )
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 from codecs import open
 from os import path
 from setuptools import find_packages, setup

--- a/tests/samples/zugferd_2p1_EN16931_Einfach-LineObjectIdentifier.xml
+++ b/tests/samples/zugferd_2p1_EN16931_Einfach-LineObjectIdentifier.xml
@@ -1,0 +1,248 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.1.1, 01.07.2020
+Beispiel Version 01.07.2020
+ 
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für 
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats 
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter 
+Technologien („ZUGFeRD Datenformat“).
+ 
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+ 
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+ 
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+ 
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+ 
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+ 
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+ 
+ <!--Right of use 
+ZUGFeRD Data format version 2.1.1, July 1, 2020
+ 
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the 
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an 
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised 
+technologies ("ZUGFeRD data format").
+ 
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD 
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a 
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non 
+discriminatory conditions.
+ 
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version 
+available at www.ferd-net.de.
+ 
+In detail, the grant of use includes 
+=====================================
+ 
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective 
+valid and accepted version (www.ferd-net.de). 
+The license includes an irrevocable right of use including the right of further development, 
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or 
+other use of the ZUGFeRD data format for hardware and/or software products and other 
+applications and services. 
+This license does not include the essential patents of the members of FeRD. The essential patents are patents 
+and patent applications worldwide which contain one or more claims that are 
+necessary claims. Necessary claims are only those claims of the essential patents which are 
+the implementation of the ZUGFeRD data format would necessarily be violated. 
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable, 
+irrevocable right of use including the right of further development, further processing and connection with 
+other products. 
+ 
+The license is provided free of charge. 
+ 
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of 
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs 
+damages, losses or liabilities in connection with an interruption of business, nor for concrete, 
+incidental, indirect, punitive or consequential damages, even if the possibility of 
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:a="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:10" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>471102</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>Rechnung gemäß Bestellung vom 01.03.2018.</ram:Content>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Lieferant GmbH				
+Lieferantenstraße 20				
+80333 München				
+Deutschland				
+Geschäftsführer: Hans Muster
+Handelsregisternummer: H A 123
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4012345001235</ram:GlobalID>
+        <ram:SellerAssignedID>TB100A4</ram:SellerAssignedID>
+        <ram:Name>Trennblätter A4</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">20.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>198.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000050986428</ram:GlobalID>
+        <ram:SellerAssignedID>ARNR2</ram:SellerAssignedID>
+        <ram:Name>Joghurt Banane</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">50.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>275.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+        <ram:AdditionalReferencedDocument>
+          <ram:IssuerAssignedID schemeID="SE">D200KKRG</ram:IssuerAssignedID>
+          <ram:TypeCode>130</ram:TypeCode>
+        </ram:AdditionalReferencedDocument>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+		<ram:ID>549910</ram:ID>
+        <ram:GlobalID schemeID="0088">4000001123452</ram:GlobalID>
+        <ram:Name>Lieferant GmbH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>80333</ram:PostcodeCode>
+          <ram:LineOne>Lieferantenstraße 20</ram:LineOne>
+          <ram:CityName>München</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">201/113/40209</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>GE2020211</ram:ID>
+        <ram:Name>Kunden AG Mitte</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>69876</ram:PostcodeCode>
+          <ram:LineOne>Kundenstraße 15</ram:LineOne>
+          <ram:CityName>Frankfurt</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>19.25</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>275.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>37.62</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>198.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018</ram:Description>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>473.00</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>473.00</ram:TaxBasisTotalAmount>
+		<ram:TaxTotalAmount currencyID="EUR">56.87</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>529.87</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>529.87</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/tests/samples/zugferd_2p2_EN16931_ElektronischeAdresse2.xml
+++ b/tests/samples/zugferd_2p2_EN16931_ElektronischeAdresse2.xml
@@ -1,0 +1,384 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.2.0, 14.02.2022
+Beispiel Version 14.02.2022
+ 
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für 
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats 
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter 
+Technologien („ZUGFeRD Datenformat“).
+ 
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+ 
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+ 
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+ 
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+ 
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+ 
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+ 
+ <!--Right of use 
+ZUGFeRD Data format version 2.2.0, February 14th, 2022
+ 
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the 
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an 
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised 
+technologies ("ZUGFeRD data format").
+ 
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD 
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a 
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non 
+discriminatory conditions.
+ 
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version 
+available at www.ferd-net.de.
+ 
+In detail, the grant of use includes 
+=====================================
+ 
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective 
+valid and accepted version (www.ferd-net.de). 
+The license includes an irrevocable right of use including the right of further development, 
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or 
+other use of the ZUGFeRD data format for hardware and/or software products and other 
+applications and services. 
+This license does not include the essential patents of the members of FeRD. The essential patents are patents 
+and patent applications worldwide which contain one or more claims that are 
+necessary claims. Necessary claims are only those claims of the essential patents which are 
+the implementation of the ZUGFeRD data format would necessarily be violated. 
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable, 
+irrevocable right of use including the right of further development, further processing and connection with 
+other products. 
+ 
+The license is provided free of charge. 
+ 
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of 
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs 
+damages, losses or liabilities in connection with an interruption of business, nor for concrete, 
+incidental, indirect, punitive or consequential damages, even if the possibility of 
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>9314110911/00/M/00/N</ram:ID>
+    <ram:TypeCode>387</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20181001</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>MUSTER-Autovermietung GMBH
+Musterstr. 99
+99199 MUSTERHAUSEN
+Geschäftsführung:
+Maxima Musterfrau
+USt-IdNr: DE136695976
+Telefon: +49 711-50885524
+www.musterlieferant.de
+HRB Nr. 372876
+Amtsgericht Musterstadt
+GLN 4304171000002
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Bei Rückfragen:
+Telefon: +49 711-50885524
+E-Mail : info@muster-autovermietung.de
+      </ram:Content>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Übergabe am 29.09.2018/ 10:35
+	  Ort: Frankfurt a. M.
+	  km: 17791
+      </ram:Content>
+    </ram:IncludedNote>
+	    <ram:IncludedNote>
+      <ram:Content>Rückgabe am 01.10.2018/ 10:19
+	  Ort: Frankfurt a. M.
+	  km: 18664
+      </ram:Content>
+    </ram:IncludedNote>
+	<ram:IncludedNote>
+      <ram:Content>Übernahme: Frankfurt
+	  Datum: 01.10.2018
+	  Zeit: 10:19
+	  km/out: 177791
+	  km/in: 18664
+	  km gefahren: 873
+	  Kennzeichen: M-MM 0000
+	  CO2: 150
+	  Bruttolistenpreis: 68300
+      </ram:Content>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Miettage</ram:Name>
+		<ram:ApplicableProductCharacteristic>
+		<ram:Description>Fahrzeug-Kennzeichen</ram:Description>
+		<ram:Value>M-MM 0000</ram:Value>
+		</ram:ApplicableProductCharacteristic>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>86.5500</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="DAY">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>173.10</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+		<ram:IncludedNote>
+          <ram:Content>Inklusiv-Kilometer waren: 873</ram:Content>
+        </ram:IncludedNote>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Navigationssystem - Garantie</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.0400</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>10.08</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+	    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>3</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Vollkasko</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>23.1000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>46.20</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+	<ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>4</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>minimale Selbstbeteiligung</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>15.5500</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>31.10</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+	<ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>5</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Personen-Unfallversicherung</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>7.9800</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>15.96</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+	<ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>6</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>Choice Upgrade</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.0400</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>10.08</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+		<ram:ID>549910</ram:ID>
+        <ram:GlobalID schemeID="0088">4333741000005</ram:GlobalID>
+		<ram:Name>MUSTER-Autovermietung</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>99199</ram:PostcodeCode>
+          <ram:LineOne>Musterstr. 99</ram:LineOne>
+          <ram:CityName>MUSTERHAUSEN</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+		<ram:URIUniversalCommunication>
+          <ram:URIID schemeID="0088">1234567890128</ram:URIID>
+        </ram:URIUniversalCommunication>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE136695976</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>9314110911</ram:ID>
+        <ram:Name>MUSTER-KUNDE GMBH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>40235</ram:PostcodeCode>
+          <ram:LineOne>KUNDENWEG 88</ram:LineOne>
+          <ram:CityName>DUESSELDORF</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+		<ram:URIUniversalCommunication>
+          <ram:URIID schemeID="9958">04 0 11 000 - 12345 12345 - 35</ram:URIID>
+        </ram:URIUniversalCommunication>
+      </ram:BuyerTradeParty>
+      <ram:BuyerOrderReferencedDocument>
+        <ram:IssuerAssignedID>B123456789</ram:IssuerAssignedID>
+        <ram:FormattedIssueDateTime>
+            <qdt:DateTimeString format="102">20180204</qdt:DateTimeString>
+        </ram:FormattedIssueDateTime>
+      </ram:BuyerOrderReferencedDocument>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180929</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+	  <ram:DespatchAdviceReferencedDocument>
+        <ram:IssuerAssignedID>L87654321012345</ram:IssuerAssignedID>
+      </ram:DespatchAdviceReferencedDocument>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>54.44</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>286.52</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+	  <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>
+          Die Leistung wurde erbracht im Zeitraum zwischen Übergabe und Rückgabe. Der Rechnungsbetrag wird über Ihre MasterCard-Kreditkarte abgebucht. Dies ist keine Aufforderung zur Zahlung. Rechnung für Ihre Unterlagen.
+        </ram:Description>
+      </ram:SpecifiedTradePaymentTerms>
+	  <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>286.52</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>286.52</ram:TaxBasisTotalAmount>
+		<ram:TaxTotalAmount currencyID="EUR">54.44</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>340.96</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>340.96</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/tests/test_mininal.py
+++ b/tests/test_mininal.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from drafthorse.models.accounting import ApplicableTradeTax
@@ -35,6 +35,11 @@ def test_readme_construction_example():
 
     doc.trade.agreement.seller.address.country_id = "DE"
     doc.trade.agreement.seller.address.country_subdivision = "Bayern"
+
+    doc.trade.agreement.seller_order.issue_date_time = datetime.now(timezone.utc)
+    doc.trade.agreement.buyer_order.issue_date_time = datetime.now(timezone.utc)
+    doc.trade.settlement.advance_payment.received_date = datetime.now(timezone.utc)
+    doc.trade.agreement.customer_order.issue_date_time = datetime.now(timezone.utc)
 
     li = LineItem()
     li.document.line_id = "1"


### PR DESCRIPTION
- corrects the NS_QDT name according to the zugferd22 specification
- extends elements.py:DateTimeElement to allow the adjustment of the inner DateTimes namespace
- updates references.py:ReferencedDocument to use NS_QDT for its DateTimeElement
- corrects profiles in reference.py for various attributes according to the zugferd22 schemata
- adds test zugferd_2p2_EN16931_ElektronischeAdresse2.xml as a variation of the official zugferd22 sample EN16931_ElektronischeAdresse.xml adding a FormattedIssueDateTime to the BuyerOrderReferencedDocument
- moves SellerOrderReferencedDocument from trade.py to references.py
- fixes DateTimeField namespace of AdvancePayment.received_date