### PR TITLE
feat: support ReceivingAdviceReferencedDocument

### DIFF
--- a/drafthorse/models/delivery.py
+++ b/drafthorse/models/delivery.py
@@ -1,4 +1,4 @@
-from . import BASIC, EXTENDED, NS_RAM
+from . import BASIC, COMFORT, EXTENDED, NS_RAM
 from .elements import Element
 from .fields import DateTimeField, Field, StringField
 from .party import (
@@ -69,7 +69,7 @@ class TradeDelivery(Element):
         DeliveryNoteReferencedDocument, required=False, profile=EXTENDED
     )
     receiving_advice: ReceivingAdviceReferencedDocument = Field(
-        ReceivingAdviceReferencedDocument, required=False, profile=EXTENDED
+        ReceivingAdviceReferencedDocument, required=False, profile=COMFORT
     )
 
     class Meta:

--- a/drafthorse/models/delivery.py
+++ b/drafthorse/models/delivery.py
@@ -9,6 +9,7 @@ from .party import (
 from .references import (
     DeliveryNoteReferencedDocument,
     DespatchAdviceReferencedDocument,
+    ReceivingAdviceReferencedDocument,
 )
 
 
@@ -66,6 +67,9 @@ class TradeDelivery(Element):
     )
     delivery_note: DeliveryNoteReferencedDocument = Field(
         DeliveryNoteReferencedDocument, required=False, profile=EXTENDED
+    )
+    receiving_advice: ReceivingAdviceReferencedDocument = Field(
+        ReceivingAdviceReferencedDocument, required=False, profile=EXTENDED
     )
 
     class Meta:

--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -108,6 +108,12 @@ class LineDespatchAdviceReferencedDocument(ReferencedDocument):
         tag = "DespatchAdviceReferencedDocument"
 
 
+class ReceivingAdviceReferencedDocument(ReferencedDocument):
+    class Meta:
+        namespace = NS_RAM
+        tag = "ReceivingAdviceReferencedDocument"
+
+
 class LineReceivingAdviceReferencedDocument(ReferencedDocument):
     line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
 


### PR DESCRIPTION
Add support for the element `ReceivingAdviceReferencedDocument` / `doc.trade.delivery.receiving_advice`.

<details>
<summary>Supported in EN16931 a.k.a. COMFORT (line 70)</summary>

https://github.com/pretix/python-drafthorse/blob/e06ba386b530537411251f79e281257463fd47bc/drafthorse/schema/Factur-X_1.0.07_EN16931_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd#L65-L72

</details>

<details>
<summary>Supported in EXTENDED (line 96)</summary>

https://github.com/pretix/python-drafthorse/blob/e06ba386b530537411251f79e281257463fd47bc/drafthorse/schema/Factur-X_1.0.07_EXTENDED_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd#L88-L98

</details>

[Example file](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/7ce3772aff315588f37e38b509173f253d340e45/cii/examples/CII_example5.xml#L331-L333)
(The example file contains [another element](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/7ce3772aff315588f37e38b509173f253d340e45/cii/examples/CII_example5.xml#L365-L367) (`udt:DateString`) that is not yet supported. Please remove this before testing.)