### PR TITLE
fix #51 - Parser should not fail on unknown elements

### DIFF
--- a/drafthorse/models/delivery.py
+++ b/drafthorse/models/delivery.py
@@ -9,6 +9,7 @@ from .party import (
 from .references import (
     DeliveryNoteReferencedDocument,
     DespatchAdviceReferencedDocument,
+    ReceivingAdviceReferencedDocument,
 )
 
 
@@ -67,6 +68,10 @@ class TradeDelivery(Element):
     delivery_note: DeliveryNoteReferencedDocument = Field(
         DeliveryNoteReferencedDocument, required=False, profile=EXTENDED
     )
+    receiving_advice: ReceivingAdviceReferencedDocument = Field(
+        ReceivingAdviceReferencedDocument, required=False, profile=EXTENDED
+    )
+
 
     class Meta:
         namespace = NS_RAM

--- a/drafthorse/models/elements.py
+++ b/drafthorse/models/elements.py
@@ -33,6 +33,7 @@ class BaseElementMeta(type):
 class Element(metaclass=BaseElementMeta):
     def __init__(self, **kwargs):
         self.required = kwargs.get("required", False)
+        self.unknown_elements = []
         self._data = OrderedDict(
             [
                 (f.name, f.initialize() if f.default or f.required else None)
@@ -81,7 +82,7 @@ class Element(metaclass=BaseElementMeta):
         if (
             not hasattr(self, key)
             and not key.startswith("_")
-            and key not in ("required",)
+            and key not in ("required","unknown_elements")
         ):
             raise AttributeError(
                 f"Element {type(self)} has no attribute '{key}'. If you set it, it would not be included in the output."
@@ -113,7 +114,9 @@ class Element(metaclass=BaseElementMeta):
                 else:
                     getattr(self, name).from_etree(child)
             else:
-                raise TypeError("Unknown element {}".format(child.tag))
+                self.unknown_elements.append(child)
+                continue
+                # raise TypeError("Unknown element {}".format(child.tag))
         return self
 
     @classmethod

--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -107,6 +107,10 @@ class LineDespatchAdviceReferencedDocument(ReferencedDocument):
         namespace = NS_RAM
         tag = "DespatchAdviceReferencedDocument"
 
+class ReceivingAdviceReferencedDocument(ReferencedDocument):
+    class Meta:
+        namespace = NS_RAM
+        tag = "ReceivingAdviceReferencedDocument"
 
 class LineReceivingAdviceReferencedDocument(ReferencedDocument):
     line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)


### PR DESCRIPTION
Add changes to fix #51 to ensure the parser doesn't fail for unknown elements and add these elements to a list for future reference. Updating fix #50 into the other dependent files.