### PR TITLE
feat: strict mode for parsing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ Parsing::
     doc = Document.parse(samplexml)
     print(doc.trade.agreement.seller.name)
 
+``Document.parse()`` taskes a boolean parameter ``strict`` which defaults to ``True``. This means that the parser will raise an error if it encounters any unknown element. If you set it to ``False``, the parser will not raise an error and parse whatever it can.
+
 Generating::
 
     import os
@@ -130,6 +132,7 @@ Generating::
     with open("output.pdf", "wb") as f:
         f.write(new_pdf_bytes)
 
+``Document.serialize()`` will validate the generated XML against the specified schema and raise an error if it is not valid. If you want to avoid validation, you can set the ``schema`` parameter to ``None``.
 
 Development
 -----------

--- a/drafthorse/models/container.py
+++ b/drafthorse/models/container.py
@@ -19,9 +19,9 @@ class Container:
     def empty_element(self):
         return self.child_type()
 
-    def add_from_etree(self, root):
+    def add_from_etree(self, root, strict=True):
         childel = self.empty_element()
-        childel.from_etree(root)
+        childel.from_etree(root, strict)
         self.add(childel)
 
 
@@ -46,7 +46,7 @@ class SimpleContainer(Container):
             self.set_element(el, child)
             el.append_to(node)
 
-    def add_from_etree(self, root):
+    def add_from_etree(self, root, strict=True):
         self.add(root.text)
 
 
@@ -60,7 +60,7 @@ class CurrencyContainer(SimpleContainer):
         el._amount = child[0]
         el._currency = child[1]
 
-    def add_from_etree(self, root):
+    def add_from_etree(self, root, strict=True):
         self.add((root.text, root.attrib.get("currencyID")))
 
 
@@ -74,7 +74,7 @@ class IDContainer(SimpleContainer):
         el._text = child[1]
         el._scheme_id = child[0]
 
-    def add_from_etree(self, root):
+    def add_from_etree(self, root, strict=True):
         self.add((root.attrib["schemeID"], root.text))
 
 
@@ -87,5 +87,5 @@ class StringContainer(SimpleContainer):
     def set_element(self, el, child):
         el._text = child
 
-    def add_from_etree(self, root):
+    def add_from_etree(self, root, strict=True):
         self.add(root.text)


### PR DESCRIPTION
Resolves #51

Introduce a strict parsing mode which defaults to `True`. This maintains the current behavior of raising en error when an unknown element is encountered. If set to `False`, the parser ignores unknown elements.

Example:

```python
Document.parse(samplexml)  # parses only known elements, raises TypeError otherwise
Document.parse(samplexml, strict=False)  # parses what it can, returns without errors
```

Implementation:

Since the `TypeError`s are usually raised in the `from_etree` method, I added the `strict` parameter in all paths leading there.