### PR TITLE
fix: supported profile for TradeDelivery members

### DIFF
--- a/drafthorse/models/delivery.py
+++ b/drafthorse/models/delivery.py
@@ -1,4 +1,4 @@
-from . import BASIC, EXTENDED, NS_RAM
+from . import BASIC, COMFORT, EXTENDED, NS_RAM
 from .elements import Element
 from .fields import DateTimeField, Field, StringField
 from .party import (
@@ -49,10 +49,11 @@ class TradeDelivery(Element):
         SupplyChainConsignment,
         default=False,
         required=False,
+        profile=EXTENDED,
         _d="Detailinformationen zur Konsignation oder Sendung",
     )
     ship_to: ShipToTradeParty = Field(
-        ShipToTradeParty, required=False, profile=EXTENDED
+        ShipToTradeParty, required=False, profile=COMFORT
     )
     ultimate_ship_to: UltimateShipToTradeParty = Field(
         UltimateShipToTradeParty, required=False, profile=EXTENDED
@@ -62,7 +63,7 @@ class TradeDelivery(Element):
     )
     event: SupplyChainEvent = Field(SupplyChainEvent, required=False, profile=BASIC)
     despatch_advice: DespatchAdviceReferencedDocument = Field(
-        DespatchAdviceReferencedDocument, required=False, profile=EXTENDED
+        DespatchAdviceReferencedDocument, required=False, profile=COMFORT
     )
     delivery_note: DeliveryNoteReferencedDocument = Field(
         DeliveryNoteReferencedDocument, required=False, profile=EXTENDED


### PR DESCRIPTION
`ShipToTradeParty` and `DespatchAdviceReferencedDocument` are also supported by the EN16931 a.k.a. COMFORT profile, while `SupplyChainConsignment` is not:

https://github.com/pretix/python-drafthorse/blob/e06ba386b530537411251f79e281257463fd47bc/drafthorse/schema/Factur-X_1.0.07_EN16931_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd#L65-L72