### PR TITLE
Suppress /OutputIntent error logging.

### DIFF
--- a/drafthorse/pdf.py
+++ b/drafthorse/pdf.py
@@ -124,8 +124,10 @@ def _get_original_output_intents(original_pdf):
                 "/DestOutputProfile"
             ].get_object()
             output_intents.append((ori_output_intent_dict, dest_output_profile_dict))
+    except KeyError as ex:
+        logger.debug("Data missing from PDF: %s", ex)
     except Exception as ex:
-        logger.error(ex)
+        logger.exception(ex)
     return output_intents
 
 


### PR DESCRIPTION
For non-compliant PDFs, output intent structure may be missing. As it is now, such cases unnecessarily log a plain `/OutputIntents` error.

Rather than logging an error, just log a debug message and carry on. This also changes to use the correct `logger.exception()` instead of `logger.error()` so the full exception gets logged if one appears.