### PR TITLE
fix for issue #61

### DIFF
--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -77,9 +77,6 @@ class TradeAgreement(Element):
     buyer_order: BuyerOrderReferencedDocument = Field(
         BuyerOrderReferencedDocument, required=False
     )
-    customer_order: UltimateCustomerOrderReferencedDocument = Field(
-        UltimateCustomerOrderReferencedDocument, required=False, profile=COMFORT
-    )
     contract: ContractReferencedDocument = Field(
         ContractReferencedDocument, required=False, profile=COMFORT
     )
@@ -91,7 +88,9 @@ class TradeAgreement(Element):
         SellerTaxRepresentativeTradeParty, required=False
     )
     procuring_project_type: ProcuringProjectType = Field(
-        ProcuringProjectType, required=False
+        ProcuringProjectType, required=False)
+    customer_order: UltimateCustomerOrderReferencedDocument = Field(
+        UltimateCustomerOrderReferencedDocument, required=False, profile=COMFORT
     )
 
     class Meta:

--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -88,7 +88,8 @@ class TradeAgreement(Element):
         SellerTaxRepresentativeTradeParty, required=False
     )
     procuring_project_type: ProcuringProjectType = Field(
-        ProcuringProjectType, required=False)
+        ProcuringProjectType, required=False
+    )
     customer_order: UltimateCustomerOrderReferencedDocument = Field(
         UltimateCustomerOrderReferencedDocument, required=False, profile=COMFORT
     )


### PR DESCRIPTION
Changed the order of SpecifiedProcuringProject to be conform to

```
<xs:complexType name="HeaderTradeAgreementType">
    <xs:sequence>
      <xs:element name="BuyerReference" type="udt:TextType" minOccurs="0"/>
      <xs:element name="SellerTradeParty" type="ram:TradePartyType"/>
      <xs:element name="BuyerTradeParty" type="ram:TradePartyType"/>
      <xs:element name="SalesAgentTradeParty" type="ram:TradePartyType" minOccurs="0"/>
      <xs:element name="BuyerTaxRepresentativeTradeParty" type="ram:TradePartyType" minOccurs="0"/>
      <xs:element name="SellerTaxRepresentativeTradeParty" type="ram:TradePartyType" minOccurs="0"/>
      <xs:element name="ProductEndUserTradeParty" type="ram:TradePartyType" minOccurs="0"/>
      <xs:element name="ApplicableTradeDeliveryTerms" type="ram:TradeDeliveryTermsType" minOccurs="0"/>
      <xs:element name="SellerOrderReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0"/>
      <xs:element name="BuyerOrderReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0"/>
      <xs:element name="QuotationReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0"/>
      <xs:element name="ContractReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0"/>
      <xs:element name="AdditionalReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0" maxOccurs="unbounded"/>
      <xs:element name="BuyerAgentTradeParty" type="ram:TradePartyType" minOccurs="0"/>
      <xs:element name="SpecifiedProcuringProject" type="ram:ProcuringProjectType" minOccurs="0"/>
      <xs:element name="UltimateCustomerOrderReferencedDocument" type="ram:ReferencedDocumentType" minOccurs="0" maxOccurs="unbounded"/>
    </xs:sequence>
```

This fixes issue #61 