### PR TITLE
add: support for multiple bank accounts

### DIFF
--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -196,7 +196,7 @@ class TradeSettlement(Element):
     invoice_currency: TaxApplicableTradeCurrencyExchange = Field(
         TaxApplicableTradeCurrencyExchange, profile=EXTENDED
     )
-    payment_means: PaymentMeans = Field(PaymentMeans)
+    payment_means: Container = MultiField(PaymentMeans, required=False, profile=EXTENDED)
     trade_tax: Container = MultiField(ApplicableTradeTax)
     period: BillingSpecifiedPeriod = Field(
         BillingSpecifiedPeriod, required=False, profile=BASIC


### PR DESCRIPTION
Changed `TradeSettlement#payment_means` to  a `MultiField` thus now multiple banks can be added.

Usage example:
```python
for bank in invoice_data.Seller.Banks:
    payment_means = PaymentMeans()
    payment_means.type_code = "ZZZ"
    if bank.IBAN:
        payment_means.payee_account.iban = bank.IBAN
    if bank.BIC:
        payment_means.payee_institution.bic = bank.BIC
    if invoice_data.Seller.Name:
        payment_means.payee_account.account_name = invoice_data.Seller.Name
    if bank.BankName:
        payment_means.information.value = bank.BankName

    doc.trade.settlement.payment_means.add(payment_means)
```

results in (quba viewer):
![banks](https://github.com/user-attachments/assets/3fff5f67-4cd8-4834-8e95-ed80b718e441)
