### PR TITLE
Fixed IncludedNote.content field type

### DIFF
--- a/drafthorse/models/note.py
+++ b/drafthorse/models/note.py
@@ -1,15 +1,14 @@
-from .container import StringContainer
 from . import BASIC, COMFORT, EXTENDED, NS_RAM
 from .elements import Element
-from .fields import MultiStringField, StringField
+from .fields import StringField
 
 
 class IncludedNote(Element):
-    content_code = StringField(NS_RAM, "ContentCode", required=False, profile=EXTENDED)
-    content: StringContainer = MultiStringField(
+    content_code: StringField = StringField(NS_RAM, "ContentCode", required=False, profile=EXTENDED)
+    content: StringField = StringField(
         NS_RAM, "Content", required=False, profile=BASIC
     )
-    subject_code = StringField(NS_RAM, "SubjectCode", required=False, profile=COMFORT)
+    subject_code: StringField = StringField(NS_RAM, "SubjectCode", required=False, profile=COMFORT)
 
     class Meta:
         namespace = NS_RAM


### PR DESCRIPTION
The content of an included note is just a single string. If you add multiple lines the validation will fail.

![grafik](https://github.com/user-attachments/assets/87e06bcb-6157-4891-aba5-0347006c2a32)

Also updated type hints of the other fields in that class.