### PR TITLE
Remove logging overwrite

### DIFF
--- a/drafthorse/pdf.py
+++ b/drafthorse/pdf.py
@@ -39,9 +39,7 @@ from pypdf.generic import (
 
 from drafthorse.xmp_schema import XMP_SCHEMA
 
-logging.basicConfig()
 logger = logging.getLogger("drafthorse")
-logger.setLevel(logging.INFO)
 
 
 def attach_xml(original_pdf, xml_data, level=None, metadata=None, lang=None):


### PR DESCRIPTION
This reverts a change from 7e0faa82f7f6a0921109d18a5589a2a4f27207f6 which led to an unconditional overwrite of global log level settings for the drafthorse logger.