### PR TITLE
Fix README example and remove unused "import os"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ Parsing::
 
 Generating::
 
-    import os
     from datetime import date, datetime, timezone
     from decimal import Decimal
 
@@ -106,7 +105,7 @@ Generating::
     li.settlement.trade_tax.type_code = "VAT"
     li.settlement.trade_tax.category_code = "E"
     li.settlement.trade_tax.rate_applicable_percent = Decimal("0.00")
-    li.settlement.monetary_summation.total_amount = (Decimal("999.00"), "EUR")
+    li.settlement.monetary_summation.total_amount = Decimal("999.00")
     doc.trade.items.add(li)
 
     trade_tax = ApplicableTradeTax()


### PR DESCRIPTION
The example code in the README no longer works with the latest version. A similar example in
https://github.com/pretix/python-drafthorse/blob/master/tests/conftest.py exists, and uses a Decimal for
doc.trade.settlement.monetary_summation.tax_total
instead of a tuple.
Change README example to do that as well.

Also, remove an unused import ("import os").

Bug: https://github.com/pretix/python-drafthorse/issues/66