### PR TITLE
Escape user input going to xmp metadata 

### DIFF
--- a/drafthorse/pdf.py
+++ b/drafthorse/pdf.py
@@ -37,6 +37,7 @@ from pypdf.generic import (
     NumberObject,
     create_string_object,
 )
+from xml.sax.saxutils import escape as xml_escape
 
 from drafthorse.xmp_schema import XMP_SCHEMA
 
@@ -155,12 +156,18 @@ def _prepare_xmp_metadata(profile, pdf_metadata):
     :param pdf_metadata: PDF metadata
     :return: metadata XML
     """
+    # Input metadata gets embedded in the XMP metadata inside XML nodes.
+    # All values _should_ be strings, but that's not asserted anywhere so convert just in case
+    escaped_metadata = {
+        key: xml_escape(str(value)) for key, value in pdf_metadata.items()
+    }
+
     xml_str = XMP_SCHEMA.format(
-        title=pdf_metadata.get("title", ""),
-        author=pdf_metadata.get("author", ""),
-        subject=pdf_metadata.get("subject", ""),
-        producer=pdf_metadata.get("producer", "pypdf"),
-        creator_tool=pdf_metadata.get("creator", "python-drafthorse"),
+        title=escaped_metadata.get("title", ""),
+        author=escaped_metadata.get("author", ""),
+        subject=escaped_metadata.get("subject", ""),
+        producer=escaped_metadata.get("producer", "pypdf"),
+        creator_tool=escaped_metadata.get("creator", "python-drafthorse"),
         timestamp=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00"),
         urn="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#",
         documenttype="INVOICE",

--- a/drafthorse/pdf.py
+++ b/drafthorse/pdf.py
@@ -340,7 +340,7 @@ def _extract_xml_info(xml_data, level=None, metadata=None):
     if level is None:
         # autodetection of Factur-X profile
         profile = doc_id.split(":")[-1]
-        if doc_id.split(":")[-1] in ["basic", "extended"]:
+        if doc_id.split(":")[-1] in ["minimum", "basic", "basicwl", "extended"]:
             profile = doc_id.split(":")[-1]
         elif doc_id.split(":")[-1].startswith("xrechnung"):
             profile = "xrechnung"

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -4,7 +4,6 @@ import pytest
 from difflib import unified_diff
 from io import BytesIO
 from pypdf import PdfReader
-from pypdf.errors import PdfReadError
 from xml.dom import minidom
 
 from drafthorse.models.document import Document
@@ -59,16 +58,7 @@ def test_sample_roundtrip(filename):
     # Read back the PDF. We don't support extensive parsing, but this way we can assert that metadata is at least present
     # and syntactically valid.
     pdf_reader = PdfReader(BytesIO(created_pdf_bytes))
-
-    if filename in (
-        "zugferd_2p3_XRECHNUNG_Betriebskostenabrechnung.xml",
-        "zugferd_2p1_EN16931_Betriebskostenabrechnung.xml",
-        "zugferd_2p1_XRECHNUNG_Betriebskostenabrechnung.xml",
-    ):
-        with pytest.raises(PdfReadError):
-            pdf_reader.xmp_metadata
-    else:
-        assert pdf_reader.xmp_metadata
+    assert pdf_reader.xmp_metadata
 
     # Parse the sample file into our internal python structure
     doc = Document.parse(origxml)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -2,9 +2,13 @@ import lxml.etree
 import os
 import pytest
 from difflib import unified_diff
+from io import BytesIO
+from pypdf import PdfReader
+from pypdf.errors import PdfReadError
 from xml.dom import minidom
 
 from drafthorse.models.document import Document
+from drafthorse.pdf import attach_xml
 from drafthorse.utils import validate_xml
 
 samples = [
@@ -43,6 +47,28 @@ def test_sample_roundtrip(filename):
 
     # Validate that the sample file is valid, otherwise the test is moot
     validate_xml(xmlout=origxml, schema=schema)
+
+    # Attach the XML to an empty PDF doc
+    with open(
+        os.path.join(os.path.dirname(__file__), "samples", "Empty.pdf"), "rb"
+    ) as f:
+        original_pdf_bytes = f.read()
+
+    created_pdf_bytes = attach_xml(original_pdf_bytes, origxml)
+
+    # Read back the PDF. We don't support extensive parsing, but this way we can assert that metadata is at least present
+    # and syntactically valid.
+    pdf_reader = PdfReader(BytesIO(created_pdf_bytes))
+
+    if filename in (
+        "zugferd_2p3_XRECHNUNG_Betriebskostenabrechnung.xml",
+        "zugferd_2p1_EN16931_Betriebskostenabrechnung.xml",
+        "zugferd_2p1_XRECHNUNG_Betriebskostenabrechnung.xml",
+    ):
+        with pytest.raises(PdfReadError):
+            pdf_reader.xmp_metadata
+    else:
+        assert pdf_reader.xmp_metadata
 
     # Parse the sample file into our internal python structure
     doc = Document.parse(origxml)


### PR DESCRIPTION
When generating XMP metadata, the data is embedded in the XML template string unescaped. Now, if any non-XML-safe data comes in, the output XMP is invalid and will make the output PDF unparseable as Factur-X.

This will produce something like this when reading the file back:
pypdf.errors.PdfReadError: XML in XmpInformation was invalid: not well-formed (invalid token)

There are two easy cases to make this occur in practice with metadata automatically extracted from Factur-X payload:
- Selling company name
- Invoice number in ExchangedDocument/ID

All metadata going to XMP generation should be escaped.

This PR does a couple of things:
- Add profile autodetection for `minimum` and `basicwl` - just a mechanical extension to the existing mechanism
- Run isort as expected on pdf.py
- Extend the roundtrip tests by having it first attach the generated XML to a PDF, and then reading the PDF back. This raises errors for a few existing tests cases
- Fix the XMP generation with escaping logic

Fixes https://github.com/pretix/python-drafthorse/issues/79