### PR TITLE
Fix codingstyle with black

### DIFF
--- a/drafthorse/models/trade.py
+++ b/drafthorse/models/trade.py
@@ -196,7 +196,9 @@ class TradeSettlement(Element):
     invoice_currency: TaxApplicableTradeCurrencyExchange = Field(
         TaxApplicableTradeCurrencyExchange, profile=EXTENDED
     )
-    payment_means: Container = MultiField(PaymentMeans, required=False, profile=EXTENDED)
+    payment_means: Container = MultiField(
+        PaymentMeans, required=False, profile=EXTENDED
+    )
     trade_tax: Container = MultiField(ApplicableTradeTax)
     period: BillingSpecifiedPeriod = Field(
         BillingSpecifiedPeriod, required=False, profile=BASIC


### PR DESCRIPTION
The CI tests expect the code to be formatted with the "black" tool, this should fix the CI check.