### PR TITLE
Avoid user assigning unimplemented fields on containers.

### DIFF
--- a/drafthorse/models/container.py
+++ b/drafthorse/models/container.py
@@ -1,4 +1,6 @@
 class Container:
+    __slots__ = ("children", "child_type")
+
     def __init__(self, child_type):
         super().__init__()
         self.children = []
@@ -26,6 +28,8 @@ class Container:
 
 
 class SimpleContainer(Container):
+    __slots__ = ("children", "child_type", "namespace", "tag")
+
     def __init__(self, child_type, namespace, tag):
         super().__init__(child_type)
         self.namespace = namespace
@@ -51,6 +55,8 @@ class SimpleContainer(Container):
 
 
 class CurrencyContainer(SimpleContainer):
+    __slots__ = ("children", "child_type", "namespace", "tag")
+
     def empty_element(self):
         from .elements import CurrencyElement
 
@@ -65,6 +71,8 @@ class CurrencyContainer(SimpleContainer):
 
 
 class IDContainer(SimpleContainer):
+    __slots__ = ("children", "child_type", "namespace", "tag")
+
     def empty_element(self):
         from .elements import IDElement
 
@@ -79,6 +87,8 @@ class IDContainer(SimpleContainer):
 
 
 class StringContainer(SimpleContainer):
+    __slots__ = ("children", "child_type", "namespace", "tag")
+
     def empty_element(self):
         from .elements import StringElement
 


### PR DESCRIPTION
Before:

    doc.trade.settlement.payment_means.type_code = "30"

was allowed but had no effect as payemnt_means is a container.

Now it gives:

    Traceback (most recent call last):
      File "/home/mdk/src/python-drafthorse/test.py", line 54, in <module>
        doc.trade.settlement.payment_means.type_code = "30"  # Virement
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'Container' object has no attribute 'type_code' and no __dict__ for setting new attributes


It allowed to find issues in the tests, but they are fixed in #100 to avoid conflicts between those two PRs:

There as a:

    doc.trade.settlement.payment_means.type_code = "ZZZ"

Instead of:

    doc.trade.settlement.payment_means.add(PaymentMeans(type_code="ZZZ"))

And there was a:

    doc.trade.settlement.advance_payment.received_date = datetime.now(timezone.utc)

Instead of:

    advance = AdvancePayment(
        received_date=datetime.now(timezone.utc), paid_amount=Decimal(42)
    )
    advance.included_trade_tax.add(
        IncludedTradeTax(
            calculated_amount=Decimal(0),
            type_code="VAT",
            category_code="E",
            rate_applicable_percent=Decimal(0),
        )
    )
    doc.trade.settlement.advance_payment.add(advance)
