### PR TITLE
Fix LineDeliveryNoteReferencedDocument missing LineID

### DIFF
--- a/drafthorse/models/references.py
+++ b/drafthorse/models/references.py
@@ -154,6 +154,8 @@ class DeliveryNoteReferencedDocument(ReferencedDocument):
 
 
 class LineDeliveryNoteReferencedDocument(ReferencedDocument):
+    line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)
+
     class Meta:
         namespace = NS_RAM
         tag = "DeliveryNoteReferencedDocument"

--- a/tests/samples/zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml
+++ b/tests/samples/zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml
@@ -1,0 +1,569 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.3.0, 18.09.2024
+Beispiel Version 18.09.2024
+ 
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für 
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats 
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter 
+Technologien („ZUGFeRD Datenformat“).
+ 
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+ 
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+ 
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+ 
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+ 
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+ 
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+ 
+ <!--Right of use 
+ZUGFeRD Data format version 2.3.0, September 18th, 2024
+ 
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the 
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an 
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised 
+technologies ("ZUGFeRD data format").
+ 
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD 
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a 
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non 
+discriminatory conditions.
+ 
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version 
+available at www.ferd-net.de.
+ 
+In detail, the grant of use includes 
+=====================================
+ 
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective 
+valid and accepted version (www.ferd-net.de). 
+The license includes an irrevocable right of use including the right of further development, 
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or 
+other use of the ZUGFeRD data format for hardware and/or software products and other 
+applications and services. 
+This license does not include the essential patents of the members of FeRD. The essential patents are patents 
+and patent applications worldwide which contain one or more claims that are 
+necessary claims. Necessary claims are only those claims of the essential patents which are 
+the implementation of the ZUGFeRD data format would necessarily be violated. 
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable, 
+irrevocable right of use including the right of further development, further processing and connection with 
+other products. 
+ 
+The license is provided free of charge. 
+ 
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of 
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs 
+damages, losses or liabilities in connection with an interruption of business, nor for concrete, 
+incidental, indirect, punitive or consequential damages, even if the possibility of 
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:TestIndicator>
+      <udt:Indicator>true</udt:Indicator>
+    </ram:TestIndicator>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>R87654321012345</ram:ID>
+    <ram:Name>WARENRECHNUNG</ram:Name>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20241115</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:ContentCode>ST3</ram:ContentCode>
+      <ram:Content>Es bestehen Rabatt- oder Bonusvereinbarungen.</ram:Content>
+      <ram:SubjectCode>AAK</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:ContentCode>EEV</ram:ContentCode>
+      <ram:Content>Der Verkäufer bleibt Eigentümer der Waren bis zu vollständigen Erfüllung der Kaufpreisforderung.</ram:Content>
+      <ram:SubjectCode>AAJ</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>MUSTERLIEFERANT GMBH
+BAHNHOFSTRASSE 99
+99199 MUSTERHAUSEN
+Geschäftsführung:
+Max Mustermann
+USt-IdNr: DE123456789
+Telefon: +49 932 431 0
+www.musterlieferant.de
+HRB Nr. 372876
+Amtsgericht Musterstadt
+GLN 4304171000002
+WEEE-Reg-Nr.: DE87654321
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Leergutwert: 46,50</ram:Content>
+    </ram:IncludedNote>
+	    <ram:IncludedNote>
+      <ram:Content>Wichtige Information: Bei Bestellungen bis zum 19.12. ist die Auslieferung bis spätestens 23.12. garantiert.</ram:Content>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4123456000014</ram:GlobalID>
+        <ram:SellerAssignedID>ZS997</ram:SellerAssignedID>
+        <ram:Name>Zitronensäure 100ml</ram:Name>
+        <ram:ApplicableProductCharacteristic>
+          <ram:Description>Verpackungsart</ram:Description>
+          <ram:Value>BO</ram:Value>
+        </ram:ApplicableProductCharacteristic>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>1.0000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>1.0000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">100.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XCT">4.0000</ram:PackageQuantity>
+        <ram:DeliveryNoteReferencedDocument>
+          <ram:IssuerAssignedID>L87654321012345</ram:IssuerAssignedID>
+          <ram:LineID>1</ram:LineID>
+        </ram:DeliveryNoteReferencedDocument>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4123456000021</ram:GlobalID>
+        <ram:SellerAssignedID>GZ250</ram:SellerAssignedID>
+        <ram:Name>Gelierzucker Extra 250g</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>1.5000</ram:ChargeAmount>
+          <ram:AppliedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:ActualAmount>0.03</ram:ActualAmount>
+            <ram:Reason>Artikelrabatt 1</ram:Reason>
+          </ram:AppliedTradeAllowanceCharge>
+          <ram:AppliedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:ActualAmount>0.02</ram:ActualAmount>
+            <ram:Reason>Artikelrabatt 2</ram:Reason>
+          </ram:AppliedTradeAllowanceCharge>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>1.4500</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">50.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XCT">1.0000</ram:PackageQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>72.50</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>3</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4123456000021</ram:GlobalID>
+        <ram:SellerAssignedID>GZ250</ram:SellerAssignedID>
+        <ram:Name>Gelierzucker Extra 250g</ram:Name>
+        <ram:Description>Artikel wie vereinbart ohne Berechnung</ram:Description>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>0.0000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>0.0000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">10.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XCT">1.0000</ram:PackageQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>0.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>4</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4100130013294</ram:GlobalID>
+        <ram:SellerAssignedID>2031</ram:SellerAssignedID>
+        <ram:Name>Bierbrau Pils 20/0500</ram:Name>
+        <ram:Description>EAN-VKE: 4100130913297</ram:Description>
+        <ram:ApplicableProductCharacteristic>
+          <ram:Description>Verpackung</ram:Description>
+          <ram:Value>Kiste</ram:Value>
+        </ram:ApplicableProductCharacteristic>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>12.0000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>12.0000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="XBC">15.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XBO">20.0000</ram:PackageQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>180.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>5</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">2001015001325</ram:GlobalID>
+        <ram:SellerAssignedID>1805</ram:SellerAssignedID>
+        <ram:Name>Leergutpfand 20 x 0,5l</ram:Name>
+        <ram:ApplicableProductCharacteristic>
+          <ram:Description>Verpackung</ram:Description>
+          <ram:Value>unverpackt</ram:Value>
+        </ram:ApplicableProductCharacteristic>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>3.1000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>3.1000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">15.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XBC">1.0000</ram:PackageQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>46.50</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>6</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4123456000038</ram:GlobalID>
+        <ram:SellerAssignedID>MP107</ram:SellerAssignedID>
+        <ram:Name>Mischpalette Joghurt Karton 3 x 20</ram:Name>
+        <ram:ApplicableProductCharacteristic>
+          <ram:Description>Verpackung</ram:Description>
+          <ram:Value>Karton</ram:Value>
+        </ram:ApplicableProductCharacteristic>
+        <ram:IncludedReferencedProduct>
+          <ram:GlobalID schemeID="0160">4123456001035</ram:GlobalID>
+          <ram:SellerAssignedID>JOG103</ram:SellerAssignedID>
+          <ram:Name>Erdbeer 20 x 150g Becher</ram:Name>
+          <ram:UnitQuantity unitCode="C62">20.0000</ram:UnitQuantity>
+        </ram:IncludedReferencedProduct>
+        <ram:IncludedReferencedProduct>
+          <ram:GlobalID schemeID="0160">4123456002032</ram:GlobalID>
+          <ram:SellerAssignedID>JOG203</ram:SellerAssignedID>
+          <ram:Name>Banane 20 x 150g Becher</ram:Name>
+          <ram:UnitQuantity unitCode="C62">20.0000</ram:UnitQuantity>
+        </ram:IncludedReferencedProduct>
+        <ram:IncludedReferencedProduct>
+          <ram:GlobalID schemeID="0160">4123456003039</ram:GlobalID>
+          <ram:SellerAssignedID>JOG303</ram:SellerAssignedID>
+          <ram:Name>Schoko 20 x 150g Becher</ram:Name>
+          <ram:UnitQuantity unitCode="C62">20.0000</ram:UnitQuantity>
+        </ram:IncludedReferencedProduct>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>30.0000</ram:ChargeAmount>
+          <ram:AppliedTradeAllowanceCharge>
+            <ram:ChargeIndicator>
+              <udt:Indicator>false</udt:Indicator>
+            </ram:ChargeIndicator>
+            <ram:ActualAmount>0.90</ram:ActualAmount>
+            <ram:Reason>Artikelrabatt 1</ram:Reason>
+          </ram:AppliedTradeAllowanceCharge>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>29.1000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">2.0000</ram:BilledQuantity>
+        <ram:PackageQuantity unitCode="XPX">1.0000</ram:PackageQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>58.20</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:ID>549910</ram:ID>
+        <ram:GlobalID schemeID="0088">4333741000005</ram:GlobalID>
+        <ram:Name>MUSTERLIEFERANT GMBH</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:TelephoneUniversalCommunication>
+            <ram:CompleteNumber>+49 932 431 500</ram:CompleteNumber>
+          </ram:TelephoneUniversalCommunication>
+          <ram:EmailURIUniversalCommunication>
+            <ram:URIID>max.mustermann@musterlieferant.de</ram:URIID>
+          </ram:EmailURIUniversalCommunication>
+        </ram:DefinedTradeContact>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>99199</ram:PostcodeCode>
+          <ram:LineOne>BAHNHOFSTRASSE 99</ram:LineOne>
+          <ram:CityName>MUSTERHAUSEN</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>009420</ram:ID>
+        <ram:GlobalID schemeID="0088">4304171000002</ram:GlobalID>
+        <ram:Name>MUSTER-KUNDE GMBH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>40235</ram:PostcodeCode>
+          <ram:LineOne>KUNDENWEG 88</ram:LineOne>
+          <ram:CityName>DUESSELDORF</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+      <ram:BuyerOrderReferencedDocument>
+        <ram:IssuerAssignedID>B123456789</ram:IssuerAssignedID>
+      </ram:BuyerOrderReferencedDocument>
+      <ram:AdditionalReferencedDocument>
+        <ram:IssuerAssignedID>A456123</ram:IssuerAssignedID>
+        <ram:TypeCode>130</ram:TypeCode>
+      </ram:AdditionalReferencedDocument>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ShipToTradeParty>
+        <ram:GlobalID schemeID="0088">4304171088093</ram:GlobalID>
+        <ram:Name>MUSTER-MARKT</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:DepartmentName>8211</ram:DepartmentName>
+        </ram:DefinedTradeContact>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>31157</ram:PostcodeCode>
+          <ram:LineOne>HAUPTSTRASSE 44</ram:LineOne>
+          <ram:CityName>SARSTEDT</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:ShipToTradeParty>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180805</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+      <ram:DeliveryNoteReferencedDocument>
+        <ram:IssuerAssignedID>L87654321012345</ram:IssuerAssignedID>
+      </ram:DeliveryNoteReferencedDocument>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:InvoiceeTradeParty>
+        <ram:ID>009420</ram:ID>
+        <ram:GlobalID schemeID="0088">4304171000002</ram:GlobalID>
+        <ram:Name>MUSTER-KUNDE GMBH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>40235</ram:PostcodeCode>
+          <ram:LineOne>KUNDENWEG 88</ram:LineOne>
+          <ram:CityName>DUESSELDORF</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:InvoiceeTradeParty>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>61.07</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>321.40</ram:BasisAmount>
+        <ram:LineTotalBasisAmount>326.50</ram:LineTotalBasisAmount>
+        <ram:AllowanceChargeBasisAmount>-5.10</ram:AllowanceChargeBasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>8.93</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>127.59</ram:BasisAmount>
+        <ram:LineTotalBasisAmount>130.70</ram:LineTotalBasisAmount>
+        <ram:AllowanceChargeBasisAmount>-3.11</ram:AllowanceChargeBasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:CalculationPercent>2.00</ram:CalculationPercent>
+        <ram:BasisAmount>280.00</ram:BasisAmount>
+        <ram:ActualAmount>5.60</ram:ActualAmount>
+        <ram:Reason>Rechnungsrabatt 1</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:CalculationPercent>2.00</ram:CalculationPercent>
+        <ram:BasisAmount>130.70</ram:BasisAmount>
+        <ram:ActualAmount>2.61</ram:ActualAmount>
+        <ram:Reason>Rechnungsrabatt 1</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:BasisAmount>280.00</ram:BasisAmount>
+        <ram:ActualAmount>2.50</ram:ActualAmount>
+        <ram:Reason>Rechnungsrabatt 2</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:BasisAmount>130.70</ram:BasisAmount>
+        <ram:ActualAmount>0.50</ram:ActualAmount>
+        <ram:Reason>Rechnungsrabatt 2</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedLogisticsServiceCharge>
+        <ram:Description>Transportkosten</ram:Description>
+        <ram:AppliedAmount>3.00</ram:AppliedAmount>
+        <ram:AppliedTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:AppliedTradeTax>
+      </ram:SpecifiedLogisticsServiceCharge>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>Bei Zahlung innerhalb 14 Tagen gewähren wir 2,0% Skonto.</ram:Description>
+        <ram:ApplicableTradePaymentDiscountTerms>
+          <ram:BasisPeriodMeasure unitCode="DAY">14</ram:BasisPeriodMeasure>
+          <ram:CalculationPercent>2.00</ram:CalculationPercent>
+        </ram:ApplicableTradePaymentDiscountTerms>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>457.20</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>3.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>11.21</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>448.99</ram:TaxBasisTotalAmount>
+		<ram:TaxTotalAmount currencyID="EUR">70.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>518.99</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>518.99</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -35,6 +35,11 @@ def prettify(xml, **kwargs):
 
 @pytest.mark.parametrize("filename", samples)
 def test_sample_roundtrip(filename):
+    # FIXME: Skip test until LineDeliveryNoteReferencedDocument.line_id field is implemented
+    # Will be dropped in the next commit
+    if filename == "zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml":
+        pytest.skip("Skipping until LineDeliveryNoteReferencedDocument.line_id is implemented")
+
     origxml = prettify(
         open(os.path.join(os.path.dirname(__file__), "samples", filename), "rb").read(),
         remove_comments=True,
@@ -78,3 +83,18 @@ def test_sample_roundtrip(filename):
 
     # Compare output XML
     assert origxml == generatedxml
+
+
+# This test will be dropped in the next commit
+def test_delivery_note_line_id_error():
+    """Test that demonstrates the TypeError when parsing DeliveryNoteReferencedDocument with LineID."""
+    filename = "zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml"
+    filepath = os.path.join(os.path.dirname(__file__), "samples", filename)
+
+    origxml = prettify(
+        open(filepath, "rb").read(),
+        remove_comments=True,
+    )
+
+    with pytest.raises(TypeError, match=r"Unknown element.*LineID"):
+        Document.parse(origxml)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -35,11 +35,6 @@ def prettify(xml, **kwargs):
 
 @pytest.mark.parametrize("filename", samples)
 def test_sample_roundtrip(filename):
-    # FIXME: Skip test until LineDeliveryNoteReferencedDocument.line_id field is implemented
-    # Will be dropped in the next commit
-    if filename == "zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml":
-        pytest.skip("Skipping until LineDeliveryNoteReferencedDocument.line_id is implemented")
-
     origxml = prettify(
         open(os.path.join(os.path.dirname(__file__), "samples", filename), "rb").read(),
         remove_comments=True,
@@ -83,18 +78,3 @@ def test_sample_roundtrip(filename):
 
     # Compare output XML
     assert origxml == generatedxml
-
-
-# This test will be dropped in the next commit
-def test_delivery_note_line_id_error():
-    """Test that demonstrates the TypeError when parsing DeliveryNoteReferencedDocument with LineID."""
-    filename = "zugferd_2p3_EXTENDED_Warenrechnung-DeliveryNoteReferencedDocument-LineID.xml"
-    filepath = os.path.join(os.path.dirname(__file__), "samples", filename)
-
-    origxml = prettify(
-        open(filepath, "rb").read(),
-        remove_comments=True,
-    )
-
-    with pytest.raises(TypeError, match=r"Unknown element.*LineID"):
-        Document.parse(origxml)


### PR DESCRIPTION
**Problem:**

`LineDeliveryNoteReferencedDocument` is missing the `line_id` field. 

All other line-level referenced document classes in the same file include:
  `line_id = StringField(NS_RAM, "LineID", required=False, profile=COMFORT)`

This includes:
  - `LineUltimateCustomerOrderReferencedDocument`
  - `LineBuyerOrderReferencedDocument`
  - `LineContractReferencedDocument`
  - `LineDespatchAdviceReferencedDocument`
  - `LineReceivingAdviceReferencedDocument`
  - `LineAdditionalReferencedDocument`

The docs also suggest that `EXTENDED` profile `DeliveryNoteReferencedDocument` has `LineID` element (this is under _SpecifiedLineTradeDelivery Grouping of delivery details on line level BT-129-00_):
<img width="720" height="152" alt="Screenshot 2026-01-20 at 19 57 18" src="https://github.com/user-attachments/assets/5d495f87-8fbb-4cd7-97f2-6651228ac3b4" />


**Solution:**

Add `line_id` to `LineDeliveryNoteReferencedDocument`