### PR TITLE
Use xrechnung.xml for XRECHNUNG attachments

### DIFF
--- a/drafthorse/pdf.py
+++ b/drafthorse/pdf.py
@@ -149,6 +149,10 @@ def _prepare_pdf_metadata_txt(pdf_metadata):
     }
 
 
+def _get_xml_attachment_filename(profile):
+    return "xrechnung.xml" if profile == "XRECHNUNG" else "factur-x.xml"
+
+
 def _prepare_xmp_metadata(profile, pdf_metadata):
     """
     Prepare pdf metadata using the FACTUR-X XMP extension schema
@@ -161,6 +165,7 @@ def _prepare_xmp_metadata(profile, pdf_metadata):
     escaped_metadata = {
         key: xml_escape(str(value)) for key, value in pdf_metadata.items()
     }
+    xml_filename = _get_xml_attachment_filename(profile)
 
     xml_str = XMP_SCHEMA.format(
         title=escaped_metadata.get("title", ""),
@@ -171,7 +176,7 @@ def _prepare_xmp_metadata(profile, pdf_metadata):
         timestamp=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00"),
         urn="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#",
         documenttype="INVOICE",
-        xml_filename="factur-x.xml",
+        xml_filename=xml_filename,
         version="1.0",
         xmp_level=profile,
     )
@@ -222,7 +227,8 @@ def _update_metadata_add_attachment(
         {NameObject("/F"): file_entry_obj, NameObject("/UF"): file_entry_obj}
     )
 
-    fname_obj = create_string_object("factur-x.xml")
+    xml_filename = _get_xml_attachment_filename(facturx_level)
+    fname_obj = create_string_object(xml_filename)
     filespec_dict = DictionaryObject(
         {
             NameObject("/AFRelationship"): NameObject(

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -58,6 +58,16 @@ def test_sample_roundtrip(filename):
     # Read back the PDF. We don't support extensive parsing, but this way we can assert that metadata is at least present
     # and syntactically valid.
     pdf_reader = PdfReader(BytesIO(created_pdf_bytes))
+    expected_xml_filename = (
+        "xrechnung.xml" if filename.split("_")[2] == "XRECHNUNG" else "factur-x.xml"
+    )
+    embedded_names = (
+        pdf_reader.trailer["/Root"]["/Names"]["/EmbeddedFiles"]["/Names"]
+    ).get_object()
+    metadata_xml = pdf_reader.trailer["/Root"]["/Metadata"].get_object().get_data()
+
+    assert str(embedded_names[0]) == expected_xml_filename
+    assert expected_xml_filename.encode() in metadata_xml
     assert pdf_reader.xmp_metadata
 
     # Parse the sample file into our internal python structure


### PR DESCRIPTION
This changes the embedded XML filename for the `XRECHNUNG` profile from
`factur-x.xml` to `xrechnung.xml` in both places where `drafthorse`
writes PDF attachment metadata:

- the XMP metadata (`fx:DocumentFileName`)
- the embedded file specification (`/F` and `/UF`)

For all other profiles, the filename remains `factur-x.xml`.

Why this change:
The requirement does not come from the core XRechnung XML specification
itself, but from the Factur-X / ZUGFeRD specification for the reference
profile `XRECHNUNG`, which requires the embedded XML file to be named
`xrechnung.xml`.

References:
- XRechnung 3.0.2: https://xeinkauf.de/app/uploads/2024/07/302-XRechnung-2024-06-20.pdf
- E-Rechnung Bund, 2022-01-07:
  https://e-rechnung-bund.de/en/new-zugferd-profile-can-be-used-for-sending-xrechnung-invoices/
- Factur-X / ZUGFeRD specification [chapter 6.2] (public mirror of 1.07.2):
  https://easyfirma.net/wp-content/uploads/2024/12/1.-FACTUR-X-1.07.2-DE.pdf